### PR TITLE
Create custom next app setup cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # create-ekko-app
 
-A fast custom scaffolding tool for spinning up a Next.js app with:
+Opinionated wrapper around `create-next-app` that asks a few extra questions and installs your preferred stack in one go.
 
-- ✅ Tailwind CSS (via create-next-app)
-- ✅ React Icons + Heroicons
-- ✅ Shadcn UI (optional)
-- ✅ Email Services (React Email + Resend)
-- ✅ Bun or npm support
+- ✅ Runs `create-next-app@latest` interactively
+- ✅ Optional add-ons with one install: **shadcn**, **Clerk**, **Convex**, **Email (react-hook-form, react-email, resend)**
+- ✅ Installs all selected deps in one `pnpm add`
+- ✅ Opens the project in VS Code (`code .`) when finished
 
 ## Usage
 
 ```bash
-npx create-ekko-app@latest
-# or
-bunx create-ekko-app@latest
+pnpm dlx create-ekko-app@latest my-app
+```
+
+This will:
+- Ask all the normal Next.js questions
+- Then ask: shadcn? clerk? convex? email?
+- Install the selected extras
+- Open the new project in VS Code
+
+If you prefer to type the name later, just run:
+
+```bash
+pnpm dlx create-ekko-app@latest
+```


### PR DESCRIPTION
Implement `create-ekko-app` CLI to streamline Next.js project setup by wrapping `create-next-app` and offering custom stack options.

---
<a href="https://cursor.com/background-agent?bcId=bc-d86538f2-bad4-4825-81f1-976a235150d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d86538f2-bad4-4825-81f1-976a235150d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

