### PR TITLE
Release v1.3.7 - drop RELEASE_TOKEN, use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,21 @@ jobs:
     version:
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        permissions:
+            contents: read
+            pull-requests: read
         outputs:
             version: ${{ steps.version.outputs.version }}
             text: ${{ steps.source.outputs.text }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v5
-              with:
-                  token: ${{ secrets.RELEASE_TOKEN }}
 
             - name: Get version source (PR title or commit message)
               id: source
               env:
                   COMMIT_MSG: ${{ github.event.head_commit.message }}
-                  GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: ./scripts/release/version/get-source.sh
 
             - name: Parse version
@@ -39,8 +40,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v5
-              with:
-                  token: ${{ secrets.RELEASE_TOKEN }}
 
             - name: Update package.json version
               env:
@@ -78,7 +77,6 @@ jobs:
               uses: actions/checkout@v5
               with:
                   ref: main
-                  token: ${{ secrets.RELEASE_TOKEN }}
 
             - name: Download npm dist artifact
               uses: actions/download-artifact@v5
@@ -122,7 +120,6 @@ jobs:
               uses: actions/checkout@v5
               with:
                   ref: main
-                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Download npm dist artifact
               uses: actions/download-artifact@v5


### PR DESCRIPTION
## Summary

- Workflow run #1 (PR #5 merge) failed on the `version` job's checkout: `Error: Input required and not supplied: token` because no `RELEASE_TOKEN` secret exists.
- Switch all four jobs to the default `GITHUB_TOKEN`. PAT not needed — bump commit uses `[skip ci]` and downstream jobs run in the same workflow run anyway.
- Bumps `.github/package.json` to `1.3.7` to exercise the full release chain on merge.

## Changes

- `version` job: add `permissions: { contents: read, pull-requests: read }` for `gh pr view`; drop explicit `token:` on checkout.
- `build` / `release` jobs: drop explicit `token:` on checkout. Already have `permissions: contents: write` for the bump push and GH Release.
- `publish` job: drop redundant explicit `token: ${{ secrets.GITHUB_TOKEN }}`.
- `.github/package.json` version: `1.3.6` → `1.3.7`.

## Test plan

- [ ] On merge, the Release workflow fires on `main` with the new `release.yml` (this PR's contents).
- [ ] `version` job parses `1.3.7` from this PR title.
- [ ] `build` job runs `update.sh` (no-op, already at 1.3.7) → `commit.sh` (skips, no diff) → builds 4 binaries → uploads artifact.
- [ ] `release` job creates `v1.3.7` GH Release with 4 archives + `latest` tag.
- [ ] `publish` job publishes `create-ekko-app@1.3.7` to npm.

⚠️ npm trusted publisher on npmjs.com must be configured for workflow filename `release.yml` before merge or the publish step will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)