### PR TITLE
Release v1.3.7 - exercise release workflow end-to-end

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ekko-app",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "CLI for scaffolding an Ekko app with selectable framework, auth, database, and tooling.",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `.github/package.json` from `1.3.6` to `1.3.7`.
- PR title includes `v1.3.7` to trigger the full release chain on merge.
- First real test of the new PR-title-driven workflow (PR #6 fix is now on main).

## Expected workflow on merge

1. `version` job parses `1.3.7` from this PR title.
2. `build` job: `update.sh` no-ops (already at 1.3.7), `commit.sh` skips (no diff), builds 4 binaries with `-X main.version=1.3.7`, uploads artifact.
3. `release` job: creates 4 tar.gz archives, force-pushes `latest` tag, creates `v1.3.7` GH Release.
4. `publish` job: publishes `create-ekko-app@1.3.7` to npm via OIDC.

## Prerequisite

⚠️ npm trusted publisher on npmjs.com must point at workflow filename `release.yml` (not `publish.yml`) before merge, or the publish step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)