### PR TITLE
Release v1.3.8 - fix npm upgrade step

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ekko-app",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "CLI for scaffolding an Ekko app with selectable framework, auth, database, and tooling.",
   "license": "MIT",
   "bin": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
             # Ensure npm 11.5.1 or later for trusted publishing
             # https://docs.npmjs.com/trusted-publishers
             - name: Update npm to latest
-              run: npm install -g npm@latest
+              run: npm install -g --force npm@latest
 
             - name: Show Node & npm versions
               run: |


### PR DESCRIPTION
## Summary

- Run [26066240570](https://github.com/ekkolyth/create-ekko-app/actions/runs/26066240570) failed on the publish job at \`npm install -g npm@latest\` with \`MODULE_NOT_FOUND: 'promise-retry'\` — known npm bug upgrading on top of the runner's preinstalled npm 10.x.
- Add \`--force\` to bypass the broken in-place upgrade.
- Bumps to v1.3.8 since v1.3.7 GitHub Release/tag already exist from the partial run (build+release succeeded; only publish failed).

## Changes

- \`.github/workflows/release.yml\`: \`npm install -g npm@latest\` → \`npm install -g --force npm@latest\`.
- \`.github/package.json\`: \`1.3.7\` → \`1.3.8\`.

## Expected on merge

Full chain: version parse \`1.3.8\` → build → archives + \`v1.3.8\` GH Release → npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)