### PR TITLE
Release v1.3.9 - use Node 24 to bypass broken bundled npm

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ekko-app",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "CLI for scaffolding an Ekko app with selectable framework, auth, database, and tooling.",
   "license": "MIT",
   "bin": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,13 +133,13 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: 22
+                  node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
-            # Ensure npm 11.5.1 or later for trusted publishing
-            # https://docs.npmjs.com/trusted-publishers
-            - name: Update npm to latest
-              run: npm install -g --force npm@latest
+            # Node 24 ships with npm 11.x — already satisfies trusted publishing minimum.
+            # Skip the global upgrade because the runner's preinstalled npm on some Node
+            # 22.x minors has a missing transitive dep (promise-retry) that makes any
+            # `npm install -g npm@*` fail before it can self-replace.
 
             - name: Show Node & npm versions
               run: |


### PR DESCRIPTION
## Summary

PR #8 still failed with the same \`Cannot find module 'promise-retry'\` error even with \`--force\`. The bundled npm on Node 22.22.2 in the runner cache is missing a transitive dep, so any \`npm\` invocation crashes before the self-upgrade can complete.

Switch the publish job to Node 24. Node 24 ships with npm 11.x which already satisfies the trusted publishing minimum (\>= 11.5.1), so we can drop the global \`npm install -g npm@latest\` step entirely.

## Changes

- \`.github/workflows/release.yml\`: \`node-version: 22\` → \`node-version: 24\`; drop the \"Update npm to latest\" step.
- \`.github/package.json\`: \`1.3.8\` → \`1.3.9\`.

## Note on stale releases

v1.3.7 and v1.3.8 GitHub Releases exist with their archive assets but were never published to npm. Safe to leave or delete after v1.3.9 ships successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)